### PR TITLE
Add 'koa-isajax' and 'koa-setincontext' to packages.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,44 +5,48 @@ only focus on koa && koa2, other see [awesome-nodejs](https://github.com/sindres
 
 ## Koa
 
-
 - koajs.com
 - [koa v1.x](https://github.com/koajs/koa)
 - [koa v2.x](https://github.com/koajs/koa/tree/v2.x)
 
 
-##  Flow control
-
+## Packages
+###  Flow control
 
 - [fly: Generator-based build system](https://github.com/brj/fly)
 
-## Upload file
 
-Middleware for handling `multipart/form-data` for koa, based on Express's multer
-
-- [koa-multer for koa 1.x](https://github.com/koa-modules/multer/tree/v0.x)
-- [koa-multer for koa 2.x](https://github.com/koa-modules/multer)
-
-## Routes
+### Routes
 
 mount-koa-routes = auto mount koajs routes（base on koa-router） with routes_folder_path
 
 - [mount-koa-routes for koa 1.x](https://github.com/moajs/mount-koa-routes/)
 - [mount-koa-routes for koa 2.x](https://github.com/moajs/mount-koa-routes/tree/next)
 
-## Api convention
+
+### Middleware
+
+- Koa multer: Middleware for handling `multipart/form-data` for koa, based on Express's multer
+    - [koa-multer for koa 1.x](https://github.com/koa-modules/multer/tree/v0.x)
+    - [koa-multer for koa 2.x](https://github.com/koa-modules/multer)
+
+- [koa-isajax](https://github.com/behind-design/koa-isajax) - Express req.xhr equivalent for Koa 2 applications.
+- [koa-setincontext](https://github.com/behind-design/koa-setincontext) - Flexible middleware for Koa 2 that lets you set properties to the ctx.state for every request.
+
+
+### Api convention
 
 koa.res.api is a koa middleware for render json api , it convention over api format
 
 - [koa.res.api for koa 1.x](https://github.com/moajs/koa.res.api)
 - [koa.res.api for koa 2.x](https://github.com/moajs/koa.res.api/tree/next)
 
-## Test
+
+### Test
 
 - [ava - Futuristic JavaScript test runner](github.com/sindresorhus/ava)
 - [ava-spec - Drop-in BDD helpers.](https://github.com/sheerun/ava-spec)
 - [cucumber-js](https://github.com/cucumber/cucumber-js)
 
-## Open Source Project Use Koa 
 
-- https://github.com/uptownhr/hackable/
+## Open Source Project Using Koa 


### PR DESCRIPTION
I've added two packages for Koa 2, and also removed the "hackable" from Open projects Using Koa, because it no longer uses it. Is now build on top of express.